### PR TITLE
[Fix] Add Coinbase Withdrawal Type

### DIFF
--- a/src/main/kotlin/com/hellocuriosity/data/models/coinbase/CoinbaseTransaction.kt
+++ b/src/main/kotlin/com/hellocuriosity/data/models/coinbase/CoinbaseTransaction.kt
@@ -28,6 +28,7 @@ data class CoinbaseTransaction(
         SELL("Sell"),
         SEND("Send"),
         STAKING("Staking Income"),
+        WITHDRAWAL("Withdrawal"),
         ;
 
         companion object {

--- a/src/main/kotlin/com/hellocuriosity/utils/CoinbaseExt.kt
+++ b/src/main/kotlin/com/hellocuriosity/utils/CoinbaseExt.kt
@@ -14,5 +14,6 @@ fun CoinbaseTransaction.TransactionType?.toFinanzflussTransactionType(): Finanzf
         CoinbaseTransaction.TransactionType.SELL -> FinanzflussTransaction.TransactionType.SELL
         CoinbaseTransaction.TransactionType.SEND -> FinanzflussTransaction.TransactionType.DERECOGNITION
         CoinbaseTransaction.TransactionType.STAKING -> FinanzflussTransaction.TransactionType.DIVIDEND
+        CoinbaseTransaction.TransactionType.WITHDRAWAL -> FinanzflussTransaction.TransactionType.DERECOGNITION
         else -> null
     }

--- a/src/test/kotlin/com/hellocuriosity/data/models/coinbase/CoinbaseTransactionTest.kt
+++ b/src/test/kotlin/com/hellocuriosity/data/models/coinbase/CoinbaseTransactionTest.kt
@@ -18,6 +18,7 @@ class CoinbaseTransactionTest {
             Testable(CoinbaseTransaction.TransactionType.SELL, "Sell"),
             Testable(CoinbaseTransaction.TransactionType.SEND, "Send"),
             Testable(CoinbaseTransaction.TransactionType.STAKING, "Staking Income"),
+            Testable(CoinbaseTransaction.TransactionType.WITHDRAWAL, "Withdrawal"),
         )
 
     @Test

--- a/src/test/kotlin/com/hellocuriosity/utils/CoinbaseExtTest.kt
+++ b/src/test/kotlin/com/hellocuriosity/utils/CoinbaseExtTest.kt
@@ -47,6 +47,10 @@ class CoinbaseExtTest {
                 FinanzflussTransaction.TransactionType.DIVIDEND,
                 CoinbaseTransaction.TransactionType.STAKING,
             ),
+            Testable(
+                FinanzflussTransaction.TransactionType.DERECOGNITION,
+                CoinbaseTransaction.TransactionType.WITHDRAWAL,
+            ),
         )
 
     @Test


### PR DESCRIPTION
## Description

This adds a missing withdrawal type.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Tests have been written
- [x] Appropriate labels have been applied
